### PR TITLE
Overspringen isn't really a word and doesn't match the 'If there are …

### DIFF
--- a/languages/nl.json
+++ b/languages/nl.json
@@ -69,7 +69,7 @@
     "Send Response": "Stuur antwoord",
     "Send Us Feedback": "Stuur ons feedback",
     "Sign up for accessibility access to bypass the hCaptcha challenge.": "Meld u aan voor toegankelijkheidstoegang om de hCaptcha-uitdaging te omzeilen.",
-    "Skip": "Overspringen",
+    "Skip": "Overslaan",
     "Skip Challenge": "Sla uitdaging over",
     "Software Bug": "Software-bug",
     "Sorry to hear that!": "Sorry dat te horen!",


### PR DESCRIPTION
…None, click Skip' translation