### PR TITLE
correct si translation for "I am human"

### DIFF
--- a/languages/si.json
+++ b/languages/si.json
@@ -27,7 +27,7 @@
     "Give feedback.": "ප්රතිචාර දක්වන්න.",
     "Having a problem?": "ගැටලුවක් තිබේද?",
     "Hide examples.": "උදාහරණ සඟවන්න.",
-    "I am human": "මම මිනිස්සු",
+    "I am human": "මම මනුෂ්‍යයෙක්",
     "If there are None, click Skip": "කිසිවක් නොමැති නම්, මඟහරින්න ක්ලික් කරන්න",
     "Inappropriate": "නුසුදුසු",
     "Info": "තොරතුරු",


### PR DESCRIPTION
The current translation says **"I am humans"** in Sinhala, Now it's corrected to relay **"I am human"**.