### PR TITLE
Correct translation of a key

### DIFF
--- a/languages/ta.json
+++ b/languages/ta.json
@@ -10,7 +10,7 @@
     "Cannot contact hCaptcha. Check your connection and try again.": "HCaptcha ஐ தொடர்பு கொள்ள முடியாது. உங்கள் இணைப்பைச் சரிபார்த்து மீண்டும் முயற்சிக்கவும்.",
     "Challenge Image {{id}}": "சவால் படம் {{id}}",
     "Challenge Text Input": "சவால் உரை உள்ளீடு",
-    "Check": "காசோலை",
+    "Check": "சரிபார்",
     "Close": "நெருக்கமான",
     "Close Modal": "மோடலை மூடு",
     "Cookies are disabled or the accessibility cookie is not set. {{enable-cookies}}": "குக்கீகள் முடக்கப்பட்டுள்ளன அல்லது அணுகல் குக்கீ அமைக்கப்படவில்லை. {{enable-cookies}}",


### PR DESCRIPTION
The translation of the confirmation button "Check" has an incorrect Tamil translation.
It reads "காசோலை (kasolai)" which translates to "Cheque" [ref 1].

The appropriate translation for "Check" would be "சரிபார்" [ref 2].

[ref 1]: https://ta.wiktionary.org/wiki/cheque
[ref 2]: https://ta.wiktionary.org/wiki/check